### PR TITLE
Fixes #1 - Added padding before decoding Base32 secret

### DIFF
--- a/google_authenticator.go
+++ b/google_authenticator.go
@@ -37,7 +37,7 @@ func getHOTPToken(secret string, interval int64) string {
 
 	//Converts secret to base32 Encoding. Base32 encoding desires a 32-character
 	//subset of the twenty-six letters A–Z and ten digits 0–9
-	key, err := base32.StdEncoding.DecodeString(strings.ToUpper(secret))
+	key, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(strings.ToUpper(secret))
 	check(err)
 	bs := make([]byte, 8)
 	binary.BigEndian.PutUint64(bs, uint64(interval))


### PR DESCRIPTION
This PR fixes #1 - added padding to the secret before Base32-decoding.

TEST RESULTS

```bash
$ go test -v
=== RUN   TestItPrefixZerosAsNeeded
--- PASS: TestItPrefixZerosAsNeeded (0.00s)
=== RUN   TestShouldNotPrefixZero
--- PASS: TestShouldNotPrefixZero (0.00s)
=== RUN   TestThatOTPGeneratedIsValid
--- PASS: TestThatOTPGeneratedIsValid (0.00s)
=== RUN   TestThatOTsNotGeneratedAndTestPanics
--- PASS: TestThatOTsNotGeneratedAndTestPanics (0.00s)
PASS
ok      google-authenticator    0.012s
```